### PR TITLE
Changed endpoint to serve an html page

### DIFF
--- a/hello.js
+++ b/hello.js
@@ -2,10 +2,25 @@ const express = require('express')
 const app = express()
 const port = 3000
 
-app.get('/', (req, res) => {
-    res.set('Content-Type', 'text/html')
-    res.send(Buffer.from('<p>Hello World from node</p>'))
-})
+app.get('/', function (req, res, next) {
+    var options = {
+      root: '.',
+      dotfiles: 'deny',
+      headers: {
+        'x-timestamp': Date.now(),
+        'x-sent': true
+      }
+    }
+  
+    var fileName = './helloPage.html'
+    res.sendFile(fileName, options, function (err) {
+      if (err) {
+        next(err)
+      } else {
+        console.log('Sent:', fileName)
+      }
+    })
+  })
 
 app.listen(port, () => {
   console.log(`Hello-node app listening on port ${port}`)

--- a/helloPage.html
+++ b/helloPage.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hello World</title>
+</head>
+<body>
+    <header>
+        <h1>Hello World from node.js</h1>
+    </header>
+
+    <main>
+        
+    </main>
+
+    <footer>
+
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
API endpoint now sends a sample html page as a response instead of plain-text html